### PR TITLE
Add application data string to PersistableSaga.cs

### DIFF
--- a/src/EventDriven.Sagas.Persistence.Abstractions/DTO/SagaSnaphotDto.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/DTO/SagaSnaphotDto.cs
@@ -72,4 +72,9 @@ public class SagaSnapshotDto
     /// Steps performed by the saga.
     /// </summary>
     public List<SagaStepDto?> Steps { get; set; } = null!;
+    
+    /// <summary>
+    /// Application data used to persist data info across steps
+    /// </summary>
+    public string? ApplicationData { get; set; } = null!;
 }

--- a/src/EventDriven.Sagas.Persistence.Abstractions/EventDriven.Sagas.Persistence.Abstractions.csproj
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/EventDriven.Sagas.Persistence.Abstractions.csproj
@@ -7,7 +7,7 @@
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <Authors>Tony Sneed</Authors>
         <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
-        <PackageVersion>1.1.1</PackageVersion>
+        <PackageVersion>1.1.2</PackageVersion>
         <Description>A set of abstractions for implementing the Saga pattern.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/event-driven-dotnet/EventDriven.Sagas</PackageProjectUrl>

--- a/src/EventDriven.Sagas.Persistence.Abstractions/PersistableSaga.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/PersistableSaga.cs
@@ -23,6 +23,11 @@ public abstract class PersistableSaga : ConfigurableSaga
     /// Saga snapshot repository.
     /// </summary>
     public ISagaSnapshotRepository? SagaSnapshotRepository { get; set; }
+    
+    /// <summary>
+    /// Application specific transition data
+    /// </summary>
+    public string? ApplicationData { get; set; } = null!;
 
     /// <summary>
     /// Persist saga.

--- a/src/EventDriven.Sagas.Persistence.Abstractions/SagaPersistAutoMapperProfile.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/SagaPersistAutoMapperProfile.cs
@@ -35,13 +35,18 @@ public class SagaPersistAutoMapperProfile: Profile
             .ForMember(dest => dest.SagaId, opt =>
                 opt.MapFrom(src => src.Id))
             .ForMember(dest => dest.SagaStarted, opt =>
-                opt.MapFrom(src => src.Started));
+                opt.MapFrom(src => src.Started))
+            .ForMember(dest => dest.ApplicationData, opt =>
+                opt.MapFrom(src => src.ApplicationData));
         CreateMap<SagaSnapshotDto, PersistableSaga>()
             .ForMember(dest => dest.Id, opt =>
                 opt.MapFrom(src => Guid.Empty))
             .ForMember(dest => dest.Id, opt =>
                 opt.MapFrom(src => src.SagaId))
             .ForMember(dest => dest.Started, opt =>
-                opt.MapFrom(src => src.SagaStarted));
+                opt.MapFrom(src => src.SagaStarted))
+            .ForMember(dest => dest.ApplicationData, opt =>
+                opt.MapFrom(src => src.ApplicationData));
+
     }
 }


### PR DESCRIPTION
Add application data string to PersistableSaga.cs
Add application data string to SagaSnaphotDto.cs
Add application data string to SagaPersistAutoMapperProfile.cs Update Packge version

**Describe your proposed changes**
This change will allow the client applications to add a piece of application tracking data allowing it to access any state information in addition to the sate of the entity. Here I use a string, but alternatively the same functionality could be accomplished with a limited string, guid or json object.  This implementation took the simplest approach.

**Put `Closes #XXXX` in your comment**
Addresses issue 1

**Additional resources**
Prior to submitting your pull request, please refer to the [Contributing Guidelines](/CONTRIBUTING.md).