### PR TITLE
Persist saga metadata

### DIFF
--- a/EventDriven.Sagas.sln
+++ b/EventDriven.Sagas.sln
@@ -70,6 +70,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "reference-archite
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventDriven.Sagas.DependencyInjection.Tests", "test\EventDriven.Sagas.DependencyInjection.Tests\EventDriven.Sagas.DependencyInjection.Tests.csproj", "{75635BC4-39E9-45D6-AB55-DE9AEE0670F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventDriven.Sagas.Persistence.Abstractions.Tests", "test\EventDriven.Sagas.Persistence.Abstractions.Tests\EventDriven.Sagas.Persistence.Abstractions.Tests.csproj", "{F61E2F95-2A59-4E0B-98E4-78204D78590D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -148,6 +150,10 @@ Global
 		{75635BC4-39E9-45D6-AB55-DE9AEE0670F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75635BC4-39E9-45D6-AB55-DE9AEE0670F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{75635BC4-39E9-45D6-AB55-DE9AEE0670F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F61E2F95-2A59-4E0B-98E4-78204D78590D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F61E2F95-2A59-4E0B-98E4-78204D78590D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F61E2F95-2A59-4E0B-98E4-78204D78590D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F61E2F95-2A59-4E0B-98E4-78204D78590D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -174,6 +180,7 @@ Global
 		{E64FBA81-81E0-429E-B83D-213BDD880284} = {2F6C2678-B38D-4784-AEDA-1DF293E1296A}
 		{C67BF2F3-1B5E-44EB-93A5-634FEC0E073F} = {2F6C2678-B38D-4784-AEDA-1DF293E1296A}
 		{75635BC4-39E9-45D6-AB55-DE9AEE0670F1} = {7340565F-A10B-4B7D-B75E-9320CAE5BD05}
+		{F61E2F95-2A59-4E0B-98E4-78204D78590D} = {7340565F-A10B-4B7D-B75E-9320CAE5BD05}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3BFC4ACA-7DDF-4583-A578-5CAB3893AE40}

--- a/reference-architecture/OrderService/Integration/Handlers/CustomerCreditReleaseFulfilledEventHandler.cs
+++ b/reference-architecture/OrderService/Integration/Handlers/CustomerCreditReleaseFulfilledEventHandler.cs
@@ -1,7 +1,8 @@
 using Common.Integration.Events;
 using Common.Integration.Models;
 using EventDriven.EventBus.Abstractions;
-using EventDriven.Sagas.Abstractions.Pools;
+using EventDriven.Sagas.Persistence.Abstractions.Pools;
+using OrderService.Domain.OrderAggregate;
 using OrderService.Repositories;
 using OrderService.Sagas.CreateOrder;
 
@@ -10,12 +11,12 @@ namespace OrderService.Integration.Handlers;
 public class CustomerCreditReleaseFulfilledEventHandler : 
     IntegrationEventHandler<CustomerCreditReleaseFulfilled>
 {
-    private readonly ISagaPool<CreateOrderSaga> _sagaPool;
+    private readonly IPersistableSagaPool<CreateOrderSaga,OrderMetadata> _sagaPool;
     private readonly IOrderRepository _orderRepository;
     private readonly ILogger<CustomerCreditReleaseFulfilledEventHandler> _logger;
 
     public CustomerCreditReleaseFulfilledEventHandler(
-        ISagaPool<CreateOrderSaga> sagaPool,
+        IPersistableSagaPool<CreateOrderSaga, OrderMetadata> sagaPool,
         IOrderRepository orderRepository,
         ILogger<CustomerCreditReleaseFulfilledEventHandler> logger)
     {

--- a/reference-architecture/OrderService/Integration/Handlers/CustomerCreditReserveFulfilledEventHandler.cs
+++ b/reference-architecture/OrderService/Integration/Handlers/CustomerCreditReserveFulfilledEventHandler.cs
@@ -1,7 +1,8 @@
 using Common.Integration.Events;
 using Common.Integration.Models;
 using EventDriven.EventBus.Abstractions;
-using EventDriven.Sagas.Abstractions.Pools;
+using EventDriven.Sagas.Persistence.Abstractions.Pools;
+using OrderService.Domain.OrderAggregate;
 using OrderService.Repositories;
 using OrderService.Sagas.CreateOrder;
 
@@ -10,12 +11,12 @@ namespace OrderService.Integration.Handlers;
 public class CustomerCreditReserveFulfilledEventHandler : 
     IntegrationEventHandler<CustomerCreditReserveFulfilled>
 {
-    private readonly ISagaPool<CreateOrderSaga> _sagaPool;
+    private readonly IPersistableSagaPool<CreateOrderSaga,OrderMetadata> _sagaPool;
     private readonly IOrderRepository _orderRepository;
     private readonly ILogger<CustomerCreditReserveFulfilledEventHandler> _logger;
 
     public CustomerCreditReserveFulfilledEventHandler(
-        ISagaPool<CreateOrderSaga> sagaPool,
+        IPersistableSagaPool<CreateOrderSaga, OrderMetadata> sagaPool,
         IOrderRepository orderRepository,
         ILogger<CustomerCreditReserveFulfilledEventHandler> logger)
     {

--- a/reference-architecture/OrderService/Integration/Handlers/ProductInventoryReleaseFulfilledEventHandler.cs
+++ b/reference-architecture/OrderService/Integration/Handlers/ProductInventoryReleaseFulfilledEventHandler.cs
@@ -1,7 +1,8 @@
 using Common.Integration.Events;
 using Common.Integration.Models;
 using EventDriven.EventBus.Abstractions;
-using EventDriven.Sagas.Abstractions.Pools;
+using EventDriven.Sagas.Persistence.Abstractions.Pools;
+using OrderService.Domain.OrderAggregate;
 using OrderService.Repositories;
 using OrderService.Sagas.CreateOrder;
 
@@ -10,12 +11,12 @@ namespace OrderService.Integration.Handlers;
 public class ProductInventoryReleaseFulfilledEventHandler : 
     IntegrationEventHandler<ProductInventoryReleaseFulfilled>
 {
-    private readonly ISagaPool<CreateOrderSaga> _sagaPool;
+    private readonly IPersistableSagaPool<CreateOrderSaga, OrderMetadata> _sagaPool;
     private readonly IOrderRepository _orderRepository;
     private readonly ILogger<ProductInventoryReleaseFulfilledEventHandler> _logger;
 
     public ProductInventoryReleaseFulfilledEventHandler(
-        ISagaPool<CreateOrderSaga> sagaPool,
+        IPersistableSagaPool<CreateOrderSaga,OrderMetadata> sagaPool,
         IOrderRepository orderRepository,
         ILogger<ProductInventoryReleaseFulfilledEventHandler> logger)
     {

--- a/reference-architecture/OrderService/Integration/Handlers/ProductInventoryReserveFulfilledEventHandler.cs
+++ b/reference-architecture/OrderService/Integration/Handlers/ProductInventoryReserveFulfilledEventHandler.cs
@@ -1,7 +1,8 @@
 using Common.Integration.Events;
 using Common.Integration.Models;
 using EventDriven.EventBus.Abstractions;
-using EventDriven.Sagas.Abstractions.Pools;
+using EventDriven.Sagas.Persistence.Abstractions.Pools;
+using OrderService.Domain.OrderAggregate;
 using OrderService.Repositories;
 using OrderService.Sagas.CreateOrder;
 
@@ -10,13 +11,13 @@ namespace OrderService.Integration.Handlers;
 public class ProductInventoryReserveFulfilledEventHandler : 
     IntegrationEventHandler<ProductInventoryReserveFulfilled>
 {
-    private readonly ISagaPool<CreateOrderSaga> _sagaPool;
+    private readonly IPersistableSagaPool<CreateOrderSaga, OrderMetadata> _sagaPool;
     private readonly IOrderRepository _orderRepository;
     private readonly ILogger<ProductInventoryReserveFulfilledEventHandler> _logger;
     public Type? SagaType { get; set; } = typeof(CreateOrderSaga);
 
     public ProductInventoryReserveFulfilledEventHandler(
-        ISagaPool<CreateOrderSaga> sagaPool,
+        IPersistableSagaPool<CreateOrderSaga,OrderMetadata> sagaPool,
         IOrderRepository orderRepository,
         ILogger<ProductInventoryReserveFulfilledEventHandler> logger)
     {

--- a/reference-architecture/OrderService/Program.cs
+++ b/reference-architecture/OrderService/Program.cs
@@ -32,7 +32,7 @@ builder.Services.AddSingleton<IOrderRepository, OrderRepository>();
 builder.Services.AddMongoDbSettings<OrderDatabaseSettings, Order>(builder.Configuration);
 builder.Services.AddMongoDbSettings<SagaConfigDatabaseSettings, SagaConfigurationDto>(builder.Configuration);
 builder.Services.AddMongoDbSettings<SagaSnapshotDatabaseSettings, SagaSnapshotDto>(builder.Configuration);
-builder.Services.AddMongoDbSettings<PersistableSagaDatabaseSettings, PersistableSagaDto>(builder.Configuration);
+builder.Services.AddMongoDbSettings<PersistableSagaDatabaseSettings, PersistableSagaMetadataDto>(builder.Configuration);
 
 // Add command and query handlers
 builder.Services.AddHandlers(typeof(Program));
@@ -44,8 +44,8 @@ builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavi
 builder.Services.AddAppSettings<CreateOrderSagaConfigSettings>(builder.Configuration);
 
 // Sagas
-builder.Services.AddSaga<CreateOrderSaga, CreateOrderSagaConfigSettings, CreateOrderSagaCommandDispatcher,
-    SagaConfigRepository, SagaSnapshotRepository, PersistableSagaRepository<CreateOrderSaga>>(builder.Configuration);
+builder.Services.AddSaga<CreateOrderSaga, OrderMetadata, CreateOrderSagaConfigSettings, CreateOrderSagaCommandDispatcher,
+    SagaConfigRepository, SagaSnapshotRepository, PersistableSagaRepository<CreateOrderSaga,OrderMetadata>>(builder.Configuration);
 
 // Event Bus and event handlers
 builder.Services.AddDaprEventBus(builder.Configuration);

--- a/src/EventDriven.Sagas.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/EventDriven.Sagas.DependencyInjection/ServiceCollectionExtensions.cs
@@ -10,11 +10,11 @@ using EventDriven.Sagas.Configuration.Abstractions;
 using EventDriven.Sagas.Configuration.Abstractions.Repositories;
 using EventDriven.Sagas.Persistence.Abstractions;
 using EventDriven.Sagas.Persistence.Abstractions.Factories;
+using EventDriven.Sagas.Persistence.Abstractions.Mapping;
 using EventDriven.Sagas.Persistence.Abstractions.Pools;
 using EventDriven.Sagas.Persistence.Abstractions.Repositories;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using SagaConfigAutoMapperProfile = EventDriven.Sagas.Configuration.Abstractions.SagaConfigAutoMapperProfile;
 
 namespace EventDriven.Sagas.DependencyInjection;
 
@@ -61,6 +61,45 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Register a concrete saga using application configuration.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+    /// <param name="configuration">The application's <see cref="IConfiguration"/>.</param>
+    /// <param name="assemblyMarkerTypes">Assembly marker types.</param>
+    /// <typeparam name="TPersistableSaga">Concrete saga type that extends PersistableSaga.</typeparam>
+    /// <typeparam name="TSagaConfigSettings">Saga configuration settings type.</typeparam>
+    /// <typeparam name="TSagaCommandDispatcher">Saga command dispatcher type.</typeparam>
+    /// <typeparam name="TSagaConfigRepository">Saga config repository type.</typeparam>
+    /// <typeparam name="TSagaSnapshotRepository">Saga snapshot repository type.</typeparam>
+    /// <typeparam name="TPersistableSagaRepository">Persistable saga repository type.</typeparam>
+    /// <typeparam name="TMetadata">Metadata type</typeparam>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddSaga<TPersistableSaga, TMetadata,
+        TSagaConfigSettings, TSagaCommandDispatcher,
+        TSagaConfigRepository, TSagaSnapshotRepository, TPersistableSagaRepository>(
+        this IServiceCollection services, 
+        IConfiguration configuration,
+        params Type[] assemblyMarkerTypes)
+        where TPersistableSaga : PersistableSaga<TMetadata>, ISagaCommandResultHandler
+        where TSagaConfigSettings : class, ISagaConfigSettings, new()
+        where TSagaCommandDispatcher : ISagaCommandDispatcher
+        where TSagaConfigRepository : class, ISagaConfigRepository
+        where TSagaSnapshotRepository : class, ISagaSnapshotRepository
+        where TPersistableSagaRepository : class, IPersistableSagaRepository<TPersistableSaga,TMetadata>
+        where TMetadata : class
+    {
+        var settings = new TSagaConfigSettings();
+        var configTypeName = typeof(TSagaConfigSettings).Name;
+        var configSection = configuration.GetSection(configTypeName);
+        configSection.Bind(settings);
+        if (settings.SagaConfigId == Guid.Empty)
+            throw new Exception($"'SagaConfigId' property not present in configuration section {configTypeName}");
+        return services.AddSaga<TPersistableSaga, TMetadata ,TSagaConfigSettings, TSagaCommandDispatcher,
+            TSagaConfigRepository, TSagaSnapshotRepository, TPersistableSagaRepository>(
+            settings.SagaConfigId, settings.OverrideLockCheck, assemblyMarkerTypes);
+    }
+
+    /// <summary>
     /// Register a concrete saga using a saga configuration identifier.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
@@ -88,6 +127,41 @@ public static class ServiceCollectionExtensions
         where TSagaSnapshotRepository : class, ISagaSnapshotRepository
         where TPersistableSagaRepository : class, IPersistableSagaRepository<TPersistableSaga>
         => services.AddSaga<TPersistableSaga, TSagaConfigSettings, TSagaCommandDispatcher,
+            TSagaConfigRepository, TSagaSnapshotRepository, TPersistableSagaRepository>(options =>
+        {
+            options.SagaConfigId = sagaConfigId;
+            options.OverrideLockCheck = overrideLockCheck;
+        }, assemblyMarkerTypes);
+
+    /// <summary>
+    /// Register a concrete saga using a saga configuration identifier.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+    /// <param name="sagaConfigId">Optional saga configuration identifier.</param>
+    /// <param name="overrideLockCheck">True to override lock check.</param>
+    /// <param name="assemblyMarkerTypes">Assembly marker types.</param>
+    /// <typeparam name="TPersistableSaga">Concrete saga type that extends PersistableSaga.</typeparam>
+    /// <typeparam name="TSagaConfigSettings">Saga configuration settings type.</typeparam>
+    /// <typeparam name="TSagaCommandDispatcher">Saga command dispatcher type.</typeparam>
+    /// <typeparam name="TSagaConfigRepository">Saga config repository type.</typeparam>
+    /// <typeparam name="TSagaSnapshotRepository">Saga snapshot repository type.</typeparam>
+    /// <typeparam name="TPersistableSagaRepository">Persistable saga repository type.</typeparam>
+    /// <typeparam name="TMetadata">Metadata Type</typeparam>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddSaga<TPersistableSaga, TMetadata,
+        TSagaConfigSettings, TSagaCommandDispatcher,
+        TSagaConfigRepository, TSagaSnapshotRepository, TPersistableSagaRepository>(
+        this IServiceCollection services, 
+        Guid? sagaConfigId = null,
+        bool overrideLockCheck = false,
+        params Type[] assemblyMarkerTypes)
+        where TPersistableSaga : PersistableSaga<TMetadata>, ISagaCommandResultHandler
+        where TSagaConfigSettings : class, ISagaConfigSettings, new()
+        where TSagaCommandDispatcher : ISagaCommandDispatcher
+        where TSagaConfigRepository : class, ISagaConfigRepository
+        where TSagaSnapshotRepository : class, ISagaSnapshotRepository
+        where TPersistableSagaRepository : class, IPersistableSagaRepository<TPersistableSaga,TMetadata>
+        where TMetadata : class => services.AddSaga<TPersistableSaga, TMetadata ,TSagaConfigSettings, TSagaCommandDispatcher,
             TSagaConfigRepository, TSagaSnapshotRepository, TPersistableSagaRepository>(options =>
         {
             options.SagaConfigId = sagaConfigId;
@@ -157,6 +231,76 @@ public static class ServiceCollectionExtensions
                 var resultDispatchers = 
                     sp.GetServices<ISagaCommandResultDispatcher>().DistinctBy(e => e.GetType()).ToList();
                 var sagaPool = new PersistableSagaPool<TPersistableSaga>(factory, resultDispatchers, repository, configOptions.OverrideLockCheck);
+                return sagaPool;
+            });
+        return services;
+    }
+
+    /// <summary>
+    /// Register a concrete saga using a configure method.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+    /// <param name="configure">Method for configuring saga options.</param>
+    /// <param name="assemblyMarkerTypes">Assembly marker types.</param>
+    /// <typeparam name="TPersistableSaga">Concrete saga type that extends PersistableSaga.</typeparam>
+    /// <typeparam name="TSagaConfigSettings">Saga configuration settings type.</typeparam>
+    /// <typeparam name="TSagaCommandDispatcher">Saga command dispatcher type.</typeparam>
+    /// <typeparam name="TSagaConfigRepository">Saga config repository type.</typeparam>
+    /// <typeparam name="TSagaSnapshotRepository">Saga snapshot repository type.</typeparam>
+    /// <typeparam name="TPersistableSagaRepository">Persistable saga repository type.</typeparam>
+    /// <typeparam name="TMetadata">Metadata type</typeparam>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddSaga<
+        TPersistableSaga, TMetadata,TSagaConfigSettings, TSagaCommandDispatcher,
+        TSagaConfigRepository, TSagaSnapshotRepository, TPersistableSagaRepository>(
+        this IServiceCollection services, 
+        Action<TSagaConfigSettings> configure,
+        params Type[] assemblyMarkerTypes)
+        where TPersistableSaga : PersistableSaga<TMetadata>, ISagaCommandResultHandler
+        where TSagaConfigSettings : class, ISagaConfigSettings, new()
+        where TSagaCommandDispatcher : ISagaCommandDispatcher
+        where TSagaConfigRepository : class, ISagaConfigRepository
+        where TSagaSnapshotRepository : class, ISagaSnapshotRepository
+        where TPersistableSagaRepository : class, IPersistableSagaRepository<TPersistableSaga,TMetadata>
+        where TMetadata : class
+        {
+        var sagaConfigOptions = new TSagaConfigSettings();
+        configure(sagaConfigOptions);
+        var assemblyName = GetSagaCommandsAssemblyName(assemblyMarkerTypes);
+        var resolver = new SagaCommandTypeResolver(assemblyName);
+        services.RegisterSagaTypes(assemblyMarkerTypes)
+            .AddSingleton(sagaConfigOptions)
+            .AddSingleton<ISagaConfigRepository, TSagaConfigRepository>()
+            .AddSingleton<ISagaSnapshotRepository, TSagaSnapshotRepository>()
+            .AddSingleton<IPersistableSagaRepository<TPersistableSaga>, TPersistableSagaRepository>()
+            .AddSingleton<ISagaCommandTypeResolver, SagaCommandTypeResolver>(_ => resolver)
+            .AddAutoMapper(cfg =>
+            {
+                SagaConfigAutoMapperProfile.SagaCommandTypeResolver = resolver;
+                SagaPersistAutoMapperProfile.SagaCommandTypeResolver = resolver;
+                cfg.AddProfile(new SagaConfigAutoMapperProfile());
+                cfg.AddProfile(new SagaPersistAutoMapperProfile());
+            }, typeof(SagaConfigAutoMapperProfile), typeof(SagaPersistAutoMapperProfile))
+            .AddSingleton<ISagaFactory<TPersistableSaga>>(sp =>
+            {
+                var dispatcher = sp.GetRequiredService<TSagaCommandDispatcher>();
+                var evaluators = sp.GetServices<ISagaCommandResultEvaluator>();
+                var checkLockHandlers = sp.GetServices<ICheckSagaLockCommandHandler>();
+                var configOptions = sp.GetRequiredService<TSagaConfigSettings>();
+                var configRepo = sp.GetRequiredService<ISagaConfigRepository>();
+                var snapshotRepo = sp.GetRequiredService<ISagaSnapshotRepository>();
+                return new PersistableSagaFactory<TPersistableSaga>(
+                    dispatcher, evaluators, checkLockHandlers,
+                    configOptions, configRepo, snapshotRepo);
+            })
+            .AddSingleton<IPersistableSagaPool<TPersistableSaga, TMetadata>>(sp =>
+            {
+                var factory = sp.GetRequiredService<ISagaFactory<TPersistableSaga>>();
+                var repository = sp.GetRequiredService<IPersistableSagaRepository<TPersistableSaga>>();
+                var configOptions = sp.GetRequiredService<TSagaConfigSettings>();
+                var resultDispatchers = 
+                    sp.GetServices<ISagaCommandResultDispatcher>().DistinctBy(e => e.GetType()).ToList();
+                var sagaPool = new PersistableSagaPool<TPersistableSaga, TMetadata>(factory, resultDispatchers, repository, configOptions.OverrideLockCheck);
                 return sagaPool;
             });
         return services;

--- a/src/EventDriven.Sagas.Persistence.Abstractions/DTO/PersistableSagaMetadataDto.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/DTO/PersistableSagaMetadataDto.cs
@@ -1,0 +1,10 @@
+namespace EventDriven.Sagas.Persistence.Abstractions.DTO;
+
+/// <inheritdoc />
+public class PersistableSagaMetadataDto : PersistableSagaDto
+{
+    /// <summary>
+    /// Saga metadata.
+    /// </summary>
+    public string Metadata { get; set; } = null!;
+}

--- a/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/IdToSagaIdValueResolver.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/IdToSagaIdValueResolver.cs
@@ -1,0 +1,16 @@
+using AutoMapper;
+using EventDriven.Sagas.Persistence.Abstractions.DTO;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Mapping;
+
+/// <inheritdoc />
+public class IdToSagaIdValueResolver<TMetadata> : 
+    IValueResolver<PersistableSaga<TMetadata>, PersistableSagaMetadataDto, Guid>
+    where TMetadata : class
+{
+    /// <inheritdoc />
+    public Guid Resolve(PersistableSaga<TMetadata> source, 
+        PersistableSagaMetadataDto destination, Guid destMember,
+        ResolutionContext context) =>
+        source.Id;
+}

--- a/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/SagaIdToIdValueResolver.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/SagaIdToIdValueResolver.cs
@@ -1,0 +1,16 @@
+using AutoMapper;
+using EventDriven.Sagas.Persistence.Abstractions.DTO;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Mapping;
+
+/// <inheritdoc />
+public class SagaIdToIdValueResolver<TMetadata> : 
+    IValueResolver<PersistableSagaMetadataDto, PersistableSaga<TMetadata>, Guid>
+    where TMetadata : class
+{
+    /// <inheritdoc />
+    public Guid Resolve(PersistableSagaMetadataDto source, 
+        PersistableSaga<TMetadata> destination, Guid destMember,
+        ResolutionContext context) =>
+        source.SagaId;
+}

--- a/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/SagaMetadataToStringValueResolver.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/SagaMetadataToStringValueResolver.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using AutoMapper;
+using EventDriven.Sagas.Persistence.Abstractions.DTO;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Mapping;
+
+/// <inheritdoc />
+public class SagaMetadataToStringValueResolver<TMetadata> :
+    IValueResolver<PersistableSaga<TMetadata>, PersistableSagaMetadataDto, string>
+    where TMetadata : class
+{
+    /// <inheritdoc />
+    public string Resolve(
+        PersistableSaga<TMetadata> source, 
+        PersistableSagaMetadataDto destination, 
+        string destMember,
+        ResolutionContext context) =>
+        JsonSerializer.Serialize(source.Metadata, typeof(TMetadata));
+}

--- a/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/SagaPersistAutoMapperProfile.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/SagaPersistAutoMapperProfile.cs
@@ -4,7 +4,7 @@ using EventDriven.Sagas.Abstractions.Commands;
 using EventDriven.Sagas.Abstractions.Mapping;
 using EventDriven.Sagas.Persistence.Abstractions.DTO;
 
-namespace EventDriven.Sagas.Persistence.Abstractions;
+namespace EventDriven.Sagas.Persistence.Abstractions.Mapping;
 
 /// <summary>
 ///  Saga auto mapper configuration.
@@ -57,5 +57,15 @@ public class SagaPersistAutoMapperProfile: Profile
                 opt.MapFrom(src => src.SagaId))
             .ForMember(dest => dest.Started, opt =>
                 opt.MapFrom(src => src.SagaStarted));
+        CreateMap(typeof(PersistableSaga<>), typeof(PersistableSagaMetadataDto))
+            .ForMember("Id", opt => opt.MapFrom(src => Guid.NewGuid()))
+            .ForMember("SagaId", opt => opt.MapFrom(typeof(IdToSagaIdValueResolver<>)))
+            .ForMember("SagaStarted", opt => opt.MapFrom(typeof(StartedToSagaStartedValueResolver<>)))
+            .ForMember("Metadata", opt => opt.MapFrom(typeof(SagaMetadataToStringValueResolver<>)));
+        CreateMap(typeof(PersistableSagaMetadataDto), typeof(PersistableSaga<>))
+            .ForMember("Id", opt => opt.MapFrom(src => Guid.NewGuid()))
+            .ForMember("Id", opt => opt.MapFrom(typeof(SagaIdToIdValueResolver<>)))
+            .ForMember("Started", opt => opt.MapFrom(typeof(SagaStartedToStartedValueResolver<>)))
+            .ForMember("Metadata", opt => opt.Ignore());
     }
 }

--- a/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/SagaStartedToStartedValueResolver.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/SagaStartedToStartedValueResolver.cs
@@ -1,0 +1,16 @@
+using AutoMapper;
+using EventDriven.Sagas.Persistence.Abstractions.DTO;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Mapping;
+
+/// <inheritdoc />
+public class SagaStartedToStartedValueResolver<TMetadata> : 
+    IValueResolver<PersistableSagaMetadataDto, PersistableSaga<TMetadata>, DateTime>
+    where TMetadata : class
+{
+    /// <inheritdoc />
+    public DateTime Resolve(PersistableSagaMetadataDto source, 
+        PersistableSaga<TMetadata> destination, DateTime destMember,
+        ResolutionContext context) =>
+        source.SagaStarted;
+}

--- a/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/StartedToSagaStartedValueResolver.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/Mapping/StartedToSagaStartedValueResolver.cs
@@ -1,0 +1,16 @@
+using AutoMapper;
+using EventDriven.Sagas.Persistence.Abstractions.DTO;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Mapping;
+
+/// <inheritdoc />
+public class StartedToSagaStartedValueResolver<TMetadata> :
+    IValueResolver<PersistableSaga<TMetadata>, PersistableSagaMetadataDto, DateTime>
+    where TMetadata : class
+{
+    /// <inheritdoc />
+    public DateTime Resolve(PersistableSaga<TMetadata> source, 
+        PersistableSagaMetadataDto destination, DateTime destMember,
+        ResolutionContext context) =>
+        source.Started;
+}

--- a/src/EventDriven.Sagas.Persistence.Abstractions/PersistableSaga.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/PersistableSaga.cs
@@ -57,13 +57,11 @@ public abstract class PersistableSaga<TMetadata> : PersistableSaga
     /// Start the saga.
     /// </summary>
     /// <param name="entity">Entity.</param>
-    /// <param name="metadata">Saga metadata.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    public virtual async Task StartSagaAsync(IEntity entity, TMetadata metadata,
+    public override async Task StartSagaAsync(IEntity entity,
         CancellationToken cancellationToken = default)
     {
-        Metadata = metadata;
         Entity = entity;
         await StartSagaAsync(entity.Id, cancellationToken);
     }

--- a/src/EventDriven.Sagas.Persistence.Abstractions/Pools/IPersistableSagaPool.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/Pools/IPersistableSagaPool.cs
@@ -1,0 +1,22 @@
+using EventDriven.Sagas.Abstractions.Pools;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Pools;
+
+/// <inheritdoc />
+public interface IPersistableSagaPool<TSaga>: ISagaPool<TSaga>
+    where TSaga : PersistableSaga
+{
+}
+
+/// <inheritdoc />
+public interface IPersistableSagaPool<TSaga, TMetaData>: IPersistableSagaPool<TSaga>
+    where TSaga : PersistableSaga
+    where TMetaData : class
+{
+    /// <summary>
+    /// Create saga and add to the pool.
+    /// </summary>
+    /// <param name="metaData">Saga metadata.</param>
+    /// <returns>Newly created saga.</returns>
+    Task<TSaga> CreateSagaAsync(TMetaData metaData);
+}

--- a/src/EventDriven.Sagas.Persistence.Abstractions/Repositories/IPersistableSagaRepository.cs
+++ b/src/EventDriven.Sagas.Persistence.Abstractions/Repositories/IPersistableSagaRepository.cs
@@ -1,12 +1,10 @@
-using EventDriven.Sagas.Abstractions;
-
 namespace EventDriven.Sagas.Persistence.Abstractions.Repositories;
 
 /// <summary>
 /// Repository interface for saga persistence.
 /// </summary>
 public interface IPersistableSagaRepository<TSaga>
-    where TSaga : Saga
+    where TSaga : PersistableSaga
 {
     /// <summary>
     /// Retrieve saga.
@@ -36,4 +34,11 @@ public interface IPersistableSagaRepository<TSaga>
     /// </summary>
     /// <param name="id">Saga identifier.</param>
     Task RemoveAsync(Guid id);
+}
+
+/// <inheritdoc />
+public interface IPersistableSagaRepository<TSaga, TMetaData>: IPersistableSagaRepository<TSaga>
+    where TSaga : PersistableSaga<TMetaData> 
+    where TMetaData : class
+{
 }

--- a/src/EventDriven.Sagas.Persistence.Mongo/Repositories/PersistableSagaRepository.cs
+++ b/src/EventDriven.Sagas.Persistence.Mongo/Repositories/PersistableSagaRepository.cs
@@ -1,5 +1,6 @@
+using System.Text.Json;
 using AutoMapper;
-using EventDriven.Sagas.Abstractions;
+using EventDriven.Sagas.Persistence.Abstractions;
 using EventDriven.Sagas.Persistence.Abstractions.DTO;
 using EventDriven.Sagas.Persistence.Abstractions.Repositories;
 using MongoDB.Driver;
@@ -13,7 +14,7 @@ namespace EventDriven.Sagas.Persistence.Mongo.Repositories;
 /// </summary>
 public class PersistableSagaRepository<TSaga> : 
     DocumentRepository<PersistableSagaDto>, IPersistableSagaRepository<TSaga>
-    where TSaga : Saga
+    where TSaga : PersistableSaga
 {
     private readonly IMapper _mapper;
     private readonly AsyncLock _syncRoot = new();
@@ -64,6 +65,80 @@ public class PersistableSagaRepository<TSaga> :
 
             existingEntity.ETag = Guid.NewGuid().ToString();
             var dto = _mapper.Map<PersistableSagaDto>(existingEntity);
+            dto.Id = Guid.NewGuid();
+            await RemoveAsync(existingEntity.Id);
+            await InsertOneAsync(dto);
+            _mapper.Map(dto, newEntity);
+            return newEntity;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task RemoveAsync(Guid id) => 
+        await DeleteOneAsync(e => e.SagaId == id);
+}
+
+/// <summary>
+/// Persistable saga repository with metadata.
+/// </summary>
+/// <typeparam name="TSaga">Saga</typeparam>
+/// <typeparam name="TMetaData">Metadata</typeparam>
+public class PersistableSagaRepository<TSaga, TMetaData> :
+    DocumentRepository<PersistableSagaMetadataDto>, IPersistableSagaRepository<TSaga, TMetaData>
+    where TSaga : PersistableSaga<TMetaData> 
+    where TMetaData : class
+{
+    private readonly IMapper _mapper;
+    private readonly AsyncLock _syncRoot = new();
+
+    /// <summary>
+    /// PersistableSagaRepository constructor.
+    /// </summary>
+    /// <param name="collection">IMongoCollection.</param>
+    /// <param name="mapper">Auto mapper.</param>
+    public PersistableSagaRepository(
+        IMongoCollection<PersistableSagaMetadataDto> collection,
+        IMapper mapper) : base(collection)
+    {
+        _mapper = mapper;
+    }
+
+    /// <inheritdoc />
+    public async Task<TSaga?> GetAsync(Guid id, TSaga newEntity)
+    {
+        var dto = await FindOneAsync(e => e.SagaId == id);
+        if (dto is null) return null;
+        _mapper.Map(dto, newEntity);
+        var metadata = JsonSerializer.Deserialize<TMetaData>(dto.Metadata);
+        newEntity.Metadata = metadata;
+        return newEntity;
+    }
+
+    /// <inheritdoc />
+    public async Task<TSaga> CreateAsync(TSaga newEntity)
+    {
+        using (await _syncRoot.LockAsync())
+        {
+            newEntity.ETag = Guid.NewGuid().ToString();
+            var dto = _mapper.Map<PersistableSagaMetadataDto>(newEntity);
+            dto.Id = Guid.NewGuid();
+            await InsertOneAsync(dto);
+            _mapper.Map(dto, newEntity);
+            return newEntity;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<TSaga> SaveAsync(TSaga existingEntity, TSaga newEntity)
+    {
+        using (await _syncRoot.LockAsync())
+        {
+            var existing = await GetAsync(existingEntity.Id, newEntity);
+            if (existing is null)
+                return await CreateAsync(newEntity);
+
+            existingEntity.ETag = Guid.NewGuid().ToString();
+            var dto = _mapper.Map<PersistableSagaMetadataDto>(existingEntity);
             dto.Id = Guid.NewGuid();
             await RemoveAsync(existingEntity.Id);
             await InsertOneAsync(dto);

--- a/test/EventDriven.Sagas.DependencyInjection.Tests/Fakes/Sagas/Repositories/FakePersistableSagaRepository.cs
+++ b/test/EventDriven.Sagas.DependencyInjection.Tests/Fakes/Sagas/Repositories/FakePersistableSagaRepository.cs
@@ -1,11 +1,11 @@
-using EventDriven.Sagas.Abstractions;
+using EventDriven.Sagas.Persistence.Abstractions;
 using EventDriven.Sagas.Persistence.Abstractions.Repositories;
 
 namespace EventDriven.Sagas.DependencyInjection.Tests.Fakes.Sagas.Repositories;
 
 public class FakePersistableSagaRepository<TSaga> :
     IPersistableSagaRepository<TSaga>
-    where TSaga : Saga
+    where TSaga : PersistableSaga
 {
     public Task<TSaga?> GetAsync(Guid id, TSaga newEntity) => throw new NotImplementedException();
 

--- a/test/EventDriven.Sagas.Persistence.Abstractions.Tests/EventDriven.Sagas.Persistence.Abstractions.Tests.csproj
+++ b/test/EventDriven.Sagas.Persistence.Abstractions.Tests/EventDriven.Sagas.Persistence.Abstractions.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\EventDriven.Sagas.Persistence.Abstractions\EventDriven.Sagas.Persistence.Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Fakes/FakeCommand.cs
+++ b/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Fakes/FakeCommand.cs
@@ -1,0 +1,5 @@
+using EventDriven.Sagas.Abstractions.Commands;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Tests.Fakes;
+
+public record FakeCommand : SagaCommand<string, string>;

--- a/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Fakes/FakeCommandDispatcher.cs
+++ b/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Fakes/FakeCommandDispatcher.cs
@@ -1,0 +1,9 @@
+using EventDriven.Sagas.Abstractions.Commands;
+using EventDriven.Sagas.Abstractions.Dispatchers;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Tests.Fakes;
+
+public class FakeCommandDispatcher : ISagaCommandDispatcher
+{
+    public Task DispatchCommandAsync(SagaCommand command, bool compensating) => throw new NotImplementedException();
+}

--- a/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Fakes/FakeMetadata.cs
+++ b/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Fakes/FakeMetadata.cs
@@ -1,0 +1,7 @@
+namespace EventDriven.Sagas.Persistence.Abstractions.Tests.Fakes;
+
+public class FakeMetadata
+{
+    public string Name { get; set; } = null!;
+    public int Age { get; set; }
+}

--- a/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Fakes/FakeSaga.cs
+++ b/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Fakes/FakeSaga.cs
@@ -1,0 +1,23 @@
+﻿using EventDriven.Sagas.Abstractions;
+using EventDriven.Sagas.Abstractions.Dispatchers;
+using EventDriven.Sagas.Abstractions.Evaluators;
+using EventDriven.Sagas.Abstractions.Handlers;
+using EventDriven.Sagas.Abstractions.Pools;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Tests.Fakes;
+
+public class FakeSaga : PersistableSaga<FakeMetadata>, ISagaCommandResultHandler
+{
+    public FakeSaga(
+        FakeMetadata metadata,
+        List<SagaStep> steps,
+        ISagaCommandDispatcher sagaCommandDispatcher, 
+        IEnumerable<ISagaCommandResultEvaluator> commandResultEvaluators, 
+        ISagaPool sagaPool) : base(sagaCommandDispatcher, commandResultEvaluators, sagaPool)
+    {
+        Metadata = metadata;
+        Steps = steps;
+    }
+
+    protected override Task<bool> CheckLock(Guid entityId) => throw new NotImplementedException();
+}

--- a/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Fakes/FakeSagaConfigRepository.cs
+++ b/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Fakes/FakeSagaConfigRepository.cs
@@ -1,0 +1,115 @@
+using EventDriven.Sagas.Abstractions;
+using EventDriven.Sagas.Configuration.Abstractions;
+using EventDriven.Sagas.Configuration.Abstractions.Repositories;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Tests.Fakes;
+
+public class FakeSagaConfigRepository : ISagaConfigRepository
+{
+    public Task<SagaConfiguration?> GetAsync(Guid id)
+    {
+        var steps = new List<SagaStep>
+            {
+                new SagaStep
+                {
+                    Sequence = 1,
+                    Action = new SagaAction
+                    {
+                        Command = new FakeCommand
+                        {
+                            Name = "SetStatePending",
+                            Result = "Pending",
+                            ExpectedResult = "Pending"
+                        },
+                        ReverseOnFailure = true
+                    },
+                    CompensatingAction = new SagaAction
+                    {
+                        Command = new FakeCommand
+                        {
+                            Name = "SetStateInitial",
+                            Result = "Initial",
+                            ExpectedResult = "Initial"
+                        }
+                    }
+                },
+                new SagaStep
+                {
+                    Sequence = 2,
+                    Action = new SagaAction
+                    {
+                        Command = new FakeCommand
+                        {
+                            Name = "ReserveCredit",
+                            Result = "Reserved",
+                            ExpectedResult = "Reserved"
+                        },
+                        ReverseOnFailure = true
+                    },
+                    CompensatingAction = new SagaAction
+                    {
+                        Command = new FakeCommand
+                        {
+                            Name = "ReleaseCredit",
+                            Result = "Available",
+                            ExpectedResult = "Available"
+                        }
+                    }
+                },
+                new SagaStep
+                {
+                    Sequence = 3,
+                    Action = new SagaAction
+                    {
+                        Command = new FakeCommand
+                        {
+                            Name = "ReserveInventory",
+                            Result = "Reserved",
+                            ExpectedResult = "Reserved"
+                        },
+                        ReverseOnFailure = true
+                    },
+                    CompensatingAction = new SagaAction
+                    {
+                        Command = new FakeCommand
+                        {
+                            Name = "ReleaseInventory",
+                            Result = "Available",
+                            ExpectedResult = "Available"
+                        }
+                    }
+                },
+                new SagaStep
+                {
+                    Sequence = 4,
+                    Action = new SagaAction
+                    {
+                        Command = new FakeCommand
+                        {
+                            Name = "SetStateCreated",
+                            Result = "Created",
+                            ExpectedResult = "Created"
+                        },
+                        ReverseOnFailure = true
+                    },
+                    CompensatingAction = new SagaAction
+                    {
+                        Command = new FakeCommand
+                        {
+                            Name = "SetStateInitial",
+                            Result = "Initial",
+                            ExpectedResult = "Initial"
+                        }
+                    }
+                }
+            };
+        var config = new SagaConfiguration { Steps = steps };
+        return Task.FromResult<SagaConfiguration?>(config);
+    }
+
+    public Task<SagaConfiguration?> AddAsync(SagaConfiguration entity) => throw new NotImplementedException();
+
+    public Task<SagaConfiguration?> UpdateAsync(SagaConfiguration entity) => throw new NotImplementedException();
+
+    public Task<int> RemoveAsync(Guid id) => throw new NotImplementedException();
+}

--- a/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Helpers/FakeMetadataEqualityComparer.cs
+++ b/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Helpers/FakeMetadataEqualityComparer.cs
@@ -1,0 +1,17 @@
+using EventDriven.Sagas.Persistence.Abstractions.Tests.Fakes;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Tests.Helpers;
+
+public class FakeMetadataEqualityComparer : IEqualityComparer<FakeMetadata>
+{
+    public bool Equals(FakeMetadata? x, FakeMetadata? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (ReferenceEquals(x, null)) return false;
+        if (ReferenceEquals(y, null)) return false;
+        if (x.GetType() != y.GetType()) return false;
+        return x.Name == y.Name && x.Age == y.Age;
+    }
+
+    public int GetHashCode(FakeMetadata obj) => HashCode.Combine(obj.Name, obj.Age);
+}

--- a/test/EventDriven.Sagas.Persistence.Abstractions.Tests/SagaPersistAutoMapperProfileTests.cs
+++ b/test/EventDriven.Sagas.Persistence.Abstractions.Tests/SagaPersistAutoMapperProfileTests.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using AutoMapper;
+using EventDriven.Sagas.Abstractions.Dispatchers;
+using EventDriven.Sagas.Abstractions.Evaluators;
+using EventDriven.Sagas.Abstractions.Factories;
+using EventDriven.Sagas.Abstractions.Handlers;
+using EventDriven.Sagas.Abstractions.Pools;
+using EventDriven.Sagas.Persistence.Abstractions.DTO;
+using EventDriven.Sagas.Persistence.Abstractions.Mapping;
+using EventDriven.Sagas.Persistence.Abstractions.Tests.Fakes;
+
+namespace EventDriven.Sagas.Persistence.Abstractions.Tests;
+
+public class SagaPersistAutoMapperProfileTests
+{
+    [Fact]
+    public void Map_PersistableSagaOfTMetadata_To_PersistableSagaMetadataDto()
+    {
+        // Arrange
+        var mapperConfig = new MapperConfiguration(
+            cfg => cfg.AddProfile<SagaPersistAutoMapperProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var source = CreateSaga();
+        
+        // Act
+        var destination = mapper.Map<PersistableSagaMetadataDto>(source);
+        
+        // Assert
+        var expectedMetadata = JsonSerializer.Serialize(source.Metadata!);
+        Assert.Equal(source.Id, destination.SagaId);
+        Assert.Equal(source.Started, destination.SagaStarted);
+        Assert.Equal(expectedMetadata, destination.Metadata);
+    }
+    
+    [Fact]
+    public void Map_PersistableSagaMetadataDto_To_PersistableSagaOfTMetadata()
+    {
+        // Arrange
+        var mapperConfig = new MapperConfiguration(
+            cfg => cfg.AddProfile<SagaPersistAutoMapperProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var source = CreateSagaDto();
+        var destination = CreateSaga();
+        destination.Id = Guid.Empty;
+        destination.Metadata = null;
+        destination.Started = new DateTime();
+        
+        // Act
+        mapper.Map(source, destination);
+        
+        // Assert
+        Assert.Equal(source.SagaId, destination.Id);
+        Assert.Equal(source.SagaStarted, destination.Started);
+    }
+
+    private PersistableSagaMetadataDto CreateSagaDto()
+    {
+        // Arrange
+        var mapperConfig = new MapperConfiguration(
+            cfg => cfg.AddProfile<SagaPersistAutoMapperProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var source = CreateSaga();
+        
+        // Act
+        var destination = mapper.Map<PersistableSagaMetadataDto>(source);
+        return destination;
+    }
+    
+    private FakeSaga CreateSaga()
+    {
+        var dispatcher = new FakeCommandDispatcher();
+        var configRepo = new FakeSagaConfigRepository();
+        var config = configRepo.GetAsync(Guid.Empty).Result;
+        // ReSharper disable once CollectionNeverUpdated.Local
+        var resultEvaluators = new List<ISagaCommandResultEvaluator>();
+        var factory = new SagaFactory<FakeSaga>(dispatcher, resultEvaluators,
+            Enumerable.Empty<ICheckSagaLockCommandHandler>());
+        var sagaPool = new InMemorySagaPool<FakeSaga>(factory, new List<ISagaCommandResultDispatcher>(), false);
+        var metadata = new FakeMetadata { Age = 29, Name = "John" };
+        var saga = new FakeSaga(metadata, config?.Steps!, dispatcher, resultEvaluators, sagaPool)
+        {
+            Id = Guid.NewGuid()
+        };
+        return saga;
+    }
+}

--- a/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Usings.cs
+++ b/test/EventDriven.Sagas.Persistence.Abstractions.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
- Add IPersistableSagaPool, IPersistableSagaPool<TSaga, TMetaData>, IPersistableSagaRepository<TSaga, TMetaData>
- Add mappings for PersistableSaga<>, PersistableSagaMetadataDto to SagaPersistAutoMapperProfile
- Add tests for mapping PersistableSaga<TMetadata> and PersistableSagaMetadataDto
- Create AddSaga overloads with TMetadata in ServiceCollectionExtensions
- Update reference architecture projects to persist saga metadata

Closes #9.